### PR TITLE
fixed issue with Update 404 links

### DIFF
--- a/.github/workflows/build-docs-dev.yml
+++ b/.github/workflows/build-docs-dev.yml
@@ -39,7 +39,7 @@ jobs:
         run: mv _build/404/index.html _build/404.html
 
       - name: Update 404 links
-        run: python docs/scripts/move_404.py _build/404.html
+        run: python docs/_scripts/move_404.py _build/404.html
 
       - name: Remove .doctrees
         run: rm -r _build/.doctrees


### PR DESCRIPTION
# Description

Changed the line in `build-docs-dev.yml` from

```yaml
- name: Update 404 links
   run: python docs/scripts/move_404.py _build/404.html
```

to 

```yaml
- name: Update 404 links
   run: python docs/_scripts/move_404.py _build/404.html
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


