### PR TITLE
Towards a 3D BabyAI-like environment, starting with PickUp

### DIFF
--- a/miniworld/entity.py
+++ b/miniworld/entity.py
@@ -135,7 +135,7 @@ class MeshEnt(Entity):
         self.static = static
         self.type = mesh_name.split("_")[0]
         self.color = mesh_name.split("_")[-1]
-        
+
         # Load the mesh
         self.mesh = ObjMesh.get(mesh_name)
 

--- a/miniworld/entity.py
+++ b/miniworld/entity.py
@@ -133,7 +133,9 @@ class MeshEnt(Entity):
         super().__init__()
 
         self.static = static
-
+        self.type = mesh_name.split("_")[0]
+        self.color = mesh_name.split("_")[-1]
+        
         # Load the mesh
         self.mesh = ObjMesh.get(mesh_name)
 

--- a/miniworld/envs/__init__.py
+++ b/miniworld/envs/__init__.py
@@ -3,11 +3,11 @@ import inspect
 import gymnasium as gym
 
 from miniworld.envs.collecthealth import CollectHealth
+from miniworld.envs.conditionalpickupobject import ConditionalPickUpObject
 from miniworld.envs.fourrooms import FourRooms
 from miniworld.envs.hallway import Hallway
 from miniworld.envs.maze import Maze, MazeS2, MazeS3, MazeS3Fast
 from miniworld.envs.oneroom import OneRoom, OneRoomS6, OneRoomS6Fast
-from miniworld.envs.conditionalpickupobject import ConditionalPickUpObject
 from miniworld.envs.pickupobjects import PickupObjects
 from miniworld.envs.putnext import PutNext
 from miniworld.envs.roomobjects import RoomObjects

--- a/miniworld/envs/__init__.py
+++ b/miniworld/envs/__init__.py
@@ -7,6 +7,7 @@ from miniworld.envs.fourrooms import FourRooms
 from miniworld.envs.hallway import Hallway
 from miniworld.envs.maze import Maze, MazeS2, MazeS3, MazeS3Fast
 from miniworld.envs.oneroom import OneRoom, OneRoomS6, OneRoomS6Fast
+from miniworld.envs.conditionalpickupobject import ConditionalPickUpObject
 from miniworld.envs.pickupobjects import PickupObjects
 from miniworld.envs.putnext import PutNext
 from miniworld.envs.roomobjects import RoomObjects

--- a/miniworld/envs/conditionalpickupobject.py
+++ b/miniworld/envs/conditionalpickupobject.py
@@ -1,0 +1,152 @@
+from typing import Optional, Tuple
+from gymnasium import spaces, utils
+from gymnasium.core import ObsType
+
+from miniworld.entity import COLOR_NAMES, Ball, Box, Key
+from miniworld.miniworld import MiniWorldEnv
+
+import copy
+
+
+class ConditionalPickUpObject(MiniWorldEnv, utils.EzPickle):
+    """
+    ## Description
+
+    Room with multiple objects. The agent collects +1 reward for picking up
+    the object mentioned in the mission, and -1 if it picks up anything else.
+
+    ## Action Space
+
+    | Num | Action                      |
+    |-----|-----------------------------|
+    | 0   | turn left                   |
+    | 1   | turn right                  |
+    | 2   | move forward                |
+    | 3   | move_back                   |
+    | 4   | pickup                      |
+    | 5   | drop                        |
+
+    ## Observation Space
+
+    The observation space is a dictionary with the following entries:
+        - image: 
+            an `ndarray` with shape `(obs_height, obs_width, 3)`
+            representing a RGB image of what the agents sees.
+        - mission:
+            a string of the form 'pick up the COLOR TYPE' where
+            COLOR and TYPE are a visible entity's color and type.  
+
+    ## Rewards:
+
+    +1 when agent picks up correct object, -1 if pickup up wrong object.
+
+    ## Arguments
+
+    ```python
+    ConditionalPickUpObject(size=12, num_objs=5, cam_pitch=-30)
+    ```
+
+    `size`: size of world
+
+    `num_objs`: number of objects
+
+    `cam_pitch`: pitch offset of the camera in degrees.
+
+    """
+
+    def __init__(self, size=12, num_objs=5, cam_pitch=-30, **kwargs):
+        assert size >= 2
+        self.size = size
+        self.num_objs = num_objs
+        self.cam_pitch = cam_pitch
+
+        MiniWorldEnv.__init__(self, max_episode_steps=400, **kwargs)
+        utils.EzPickle.__init__(self, size, num_objs, **kwargs)
+        
+        image_observation_space = self.observation_space
+        self.observation_space = spaces.Dict({
+            "image": image_observation_space,
+            "mission": spaces.Text(max_length=10),
+        })
+
+        # Reduce the action space
+        self.action_space = spaces.Discrete(self.actions.drop + 1)
+
+    def _gen_world(self):
+        self.add_rect_room(
+            min_x=0,
+            max_x=self.size,
+            min_z=0,
+            max_z=self.size,
+            wall_tex="brick_wall",
+            floor_tex="asphalt",
+            no_ceiling=True,
+        )
+
+        obj_types = [Ball, Box, Key]
+        colorlist = list(COLOR_NAMES)
+        
+        obj_list = []
+        while len(obj_list)<self.num_objs:
+            obj_type = obj_types[self.np_random.choice(len(obj_types))]
+            color = colorlist[self.np_random.choice(len(colorlist))]
+            
+            obj_descr = (obj_type, color)
+            if obj_descr in obj_list:   continue
+
+            obj_list.append(obj_descr)
+
+            if obj_type == Box:
+                self.place_entity(Box(color=color, size=0.9))
+            if obj_type == Ball:
+                self.place_entity(Ball(color=color, size=0.9))
+            if obj_type == Key:
+                self.place_entity(Key(color=color))
+
+        self.place_agent()
+        self.agent.cam_pitch = self.cam_pitch
+
+        #Create mission:
+        obj = self.np_random.choice(obj_list)
+        obj_color = obj[1]
+        obj_type = obj[0].__name__.lower()
+        self.mission = f"pick up the {obj_color} {obj_type}"
+
+    def reset(
+        self, *, seed: Optional[int] = None, options: Optional[dict] = None
+    ) -> Tuple[ObsType, dict]:
+        """
+        Reset the simulation at the start of a new episode
+        This also randomizes many environment parameters (domain randomization)
+        """
+        obs, info = super().reset(seed=seed)
+
+        output_d = {
+            "image": obs,
+            "mission": copy.deepcopy(self.mission),
+        }
+        
+        return output_d, info
+
+    def step(self, action):
+        self.agent.cam_pitch = self.cam_pitch
+        obs, reward, termination, truncation, info = super().step(action)
+
+        if self.agent.carrying:
+            obj_type = type(self.agent.carrying).__name__.lower()
+            obj_color = getattr(self.agent.carrying, "color", None)
+            if obj_color in self.mission \
+            and obj_type in self.mission:
+                reward = 1
+            else:
+                reward = -1
+            
+            if reward>0:
+                termination = True
+        
+        output_d = {
+            "image": obs,
+            "mission": copy.deepcopy(self.mission),
+        }
+
+        return output_d, reward, termination, truncation, info

--- a/miniworld/envs/conditionalpickupobject.py
+++ b/miniworld/envs/conditionalpickupobject.py
@@ -7,6 +7,7 @@ from miniworld.miniworld import MiniWorldEnv
 
 import copy
 
+charset = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ")
 
 class ConditionalPickUpObject(MiniWorldEnv, utils.EzPickle):
     """
@@ -66,7 +67,7 @@ class ConditionalPickUpObject(MiniWorldEnv, utils.EzPickle):
         image_observation_space = self.observation_space
         self.observation_space = spaces.Dict({
             "image": image_observation_space,
-            "mission": spaces.Text(max_length=10),
+            "mission": spaces.Text(max_length=100, charset=charset),
         })
 
         # Reduce the action space

--- a/scripts/manual_control.py
+++ b/scripts/manual_control.py
@@ -69,10 +69,11 @@ def step(action):
         env.reset()
 
     env.render()
-    
+
     if isinstance(obs, dict):
         if "mission" in obs:
             print(f"Mission: {obs['mission']}")
+
 
 @env.unwrapped.window.event
 def on_key_press(symbol, modifiers):

--- a/scripts/manual_control.py
+++ b/scripts/manual_control.py
@@ -69,7 +69,10 @@ def step(action):
         env.reset()
 
     env.render()
-
+    
+    if isinstance(obs, dict):
+        if "mission" in obs:
+            print(f"Mission: {obs['mission']}")
 
 @env.unwrapped.window.event
 def on_key_press(symbol, modifiers):


### PR DESCRIPTION
# Description

Following the same motivations as the BabyAI benchmark, this pull request aims to emulate the BabyAI's Pickup environment, but this time using a 3D environment.

Why is it important to propose a 3D BabyAI-like environment?
[[Hill et al., 2020]'s work ](https://arxiv.org/abs/1910.00571) identified the egocentric viewpoint within a 3D environment as an important factor impacting trained agent's systematicity (cf. Section 4.3 and 4.4).
Given that the BabyAI benchmark is a prominent systematicity benchmark, it would be interesting to be able to verify that insight in an apple-to-apple comparison, whcih was not possible until now since there exists no environment like a 3D BabyAI.
This pull request proposes to start to fix that gap.

Dependencies have not changed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes