### PR TITLE
add miniworld import so the registry contains the envs

### DIFF
--- a/docs/_scripts/gen_docs_page.py
+++ b/docs/_scripts/gen_docs_page.py
@@ -3,6 +3,8 @@ import re
 
 import gymnasium as gym
 
+import miniworld  # noqa: F401
+
 
 # From python docs
 def trim(docstring):


### PR DESCRIPTION
# Description

The registry doesn't return Miniworld environments without importing the miniworld package.