### PR TITLE
Bug fixed in intersect

### DIFF
--- a/miniworld/miniworld.py
+++ b/miniworld/miniworld.py
@@ -943,6 +943,15 @@ class MiniWorldEnv(gym.Env):
         px, _, pz = pos
         pos = np.array([px, 0, pz])
 
+        # Find room containing the position
+        room = None
+        for r in self.rooms:
+            if r.point_inside(pos):
+                room = r
+                break
+        if room is None:
+            return True   # The position is outside of the rooms
+        
         # Check for intersection with walls
         if intersect_circle_segs(pos, radius, self.wall_segs):
             return True


### PR DESCRIPTION
# Description

If the forward step is large enough (I guess larger than the agent's radius), the new position of the agent may be outside of the world. Thus, one needs to check that it remains inside. With the current version of intersect_circle_segs this doesn't happen due to clipping and norm operations.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes