### PR TITLE
fix: use unwrapped env to access internal vars

### DIFF
--- a/miniworld/manual_control.py
+++ b/miniworld/manual_control.py
@@ -44,19 +44,19 @@ class ManualControl:
                 self.env.close()
 
             if symbol == key.UP:
-                self.step(self.env.actions.move_forward)
+                self.step(self.env.unwrapped.actions.move_forward)
             elif symbol == key.DOWN:
-                self.step(self.env.actions.move_back)
+                self.step(self.env.unwrapped.actions.move_back)
             elif symbol == key.LEFT:
-                self.step(self.env.actions.turn_left)
+                self.step(self.env.unwrapped.actions.turn_left)
             elif symbol == key.RIGHT:
-                self.step(self.env.actions.turn_right)
+                self.step(self.env.unwrapped.actions.turn_right)
             elif symbol == key.PAGEUP or symbol == key.P:
-                self.step(self.env.actions.pickup)
+                self.step(self.env.unwrapped.actions.pickup)
             elif symbol == key.PAGEDOWN or symbol == key.D:
-                self.step(self.env.actions.drop)
+                self.step(self.env.unwrapped.actions.drop)
             elif symbol == key.ENTER:
-                self.step(self.env.actions.done)
+                self.step(self.env.unwrapped.actions.done)
 
         @env.unwrapped.window.event
         def on_key_release(symbol, modifiers):
@@ -78,9 +78,9 @@ class ManualControl:
     def step(self, action):
         print(
             "step {}/{}: {}".format(
-                self.env.step_count + 1,
-                self.env.max_episode_steps,
-                self.env.actions(action).name,
+                self.env.unwrapped.step_count + 1,
+                self.env.unwrapped.max_episode_steps,
+                self.env.unwrapped.actions(action).name,
             )
         )
 


### PR DESCRIPTION
# Description

Fixes issue #118 

1. gymnasium.make() creates a wrapper object around actual env
2. attributes such as "actions" are not accessible through a wrapper

The fix is to replace usage of `self.env` with `self.env.unwrapped` everywhere there is access to internals of the Env object.
## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up) - this is complaining about pretty much code base. Present fix does not introduce new warnings.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
